### PR TITLE
feat: Setup modules for DB connection

### DIFF
--- a/db.js
+++ b/db.js
@@ -1,0 +1,63 @@
+const { Pool } = require('pg');
+
+const pool = new Pool();
+
+/* This module contains all the things necessary to talk to the DB including
+ * some convenience functions. Note that you *have* to connect to the database
+ * as the `hp_authenticator` role. Since that's the entrypoint role that can
+ * switch to `hp_anon` or `hp_user`, and nothing else. Its permissions are locked
+ * down. Connecting to the database as any user with any elevated permissions will
+ * be problematic. Like, really problematic. */
+db = {
+  /* Use this query when you want to check if the user is authenticated. Really,
+   * this should be named authorization but whatever. */
+  authenticate_query: async (user_id, query, query_args) => {
+    const client = await pool.connect();
+    const set_role_query = 'SET LOCAL ROLE hp_anon';
+    const set_config_query = 'SELECT set_config(\'claims.user_id\', $1::TEXT, true)';
+    const authenticate_query = 'SELECT auth.authenticate()';
+
+    try {
+      await client.query('BEGIN');
+      await client.query(set_role_query);
+
+      if (user_id != null) {
+        await client.query(set_config_query, [user_id]);
+      }
+
+      await client.query(authenticate_query);
+
+      const res = await client.query(query, query_args);
+
+      await client.query('COMMIT');
+
+      return res;
+    } catch(e) {
+      await client.query('ROLLBACK') ;
+      throw e
+    } finally {
+      client.release();
+    }
+  },
+  /// Use this for anything else that doesn't need authorization.
+  query: async (query, query_args) => {
+    const client = await pool.connect();
+    const set_role_query = 'SET LOCAL ROLE hp_anon';
+
+    try {
+      await client.query('BEGIN');
+      await client.query(set_role_query);
+      const res = client.query(query, query_args);
+      await client.query('END');
+
+      return res;
+    } catch(e) {
+      await client.query('ROLLBACK');
+      throw e;
+    } finally {
+      client.release();
+    }
+  }
+};
+
+module.exports = db;

--- a/plan.js
+++ b/plan.js
@@ -1,0 +1,41 @@
+const db = require('./db');
+
+plan = {
+  list_plans: async (user_id) => {
+    try {
+      const res = await db.authenticate_query(
+        user_id,
+        'SELECT * FROM api.list_plans()',
+        []
+      );
+
+      return {code: 200, payload: res.rows[0].list_plans};
+    } catch (e) {
+      parse_error(e);
+    }
+  }
+};
+
+/// Parses postgres errors into consumable JSON (with the status code).
+function parse_error(e) {
+  switch(e.code) {
+    case '42501':
+      return {
+        code: 401,
+        payload: {
+          error_code: 'E001',
+          message: 'E001: You are not authorized to access this resource.'
+        }
+      };
+    default:
+      return {
+        code: 500,
+        payload: {
+          error_code: 'E002',
+          message: 'E002: Something terribly wrong has happened.'
+        }
+      };
+  }
+}
+
+module.exports = plan;

--- a/routes/plans.js
+++ b/routes/plans.js
@@ -1,9 +1,13 @@
 var express = require('express');
 var router = express.Router();
+let plan = require('../plan');
 
 // Index plans
-router.get('/', function(req, res, next) {
-  res.send('respond with a resource');
+router.get('/', async function(req, res, next) {
+  const json = await plan.list_plans('1');
+
+  res.status(json.code);
+  res.send(JSON.stringify(json.payload));
 });
 
 // Get plan details


### PR DESCRIPTION
I added a sample endpoint to work with. This does not have any JWT
authentication yet, that's for another PR. This has two types of
queries:

    * `authenticate_query/3` for queries that need to switch roles; and
    * `query/2` for queries that only need the `hp_anon` role.

These are convenience functions that will set the necessary things
needed for each query transaction, so that I don't have to do it over
and over again.